### PR TITLE
This commit corrects the severity level mapping to align with the off…

### DIFF
--- a/custom_components/lu_alert/coordinator.py
+++ b/custom_components/lu_alert/coordinator.py
@@ -38,11 +38,17 @@ SEVERITY_ORDER = {
 
 # Mapping from cb-lu-level parameter to Severity enum
 LEVEL_TO_SEVERITY = {
+    # Official mapping from lu-alert.lu (N1=Red, N2=Orange, N3=Yellow)
+    "N1": Severity.EXTREME,
+    "N2": Severity.SEVERE,
+    "N3": Severity.MODERATE,
+
+    # Fallback for older or different formats observed in data
+    "ALERT_LVL_4": Severity.EXTREME,   # Red
+    "ALERT_LVL_3": Severity.SEVERE,    # Orange
+    "ALERT_LVL_2": Severity.MODERATE,  # Yellow
     "ALERT_LVL_1": Severity.MINOR,
-    "ALERT_LVL_2": Severity.SEVERE,
-    "LU-Alert Amber": Severity.MODERATE,
-    "ALERT_LVL_3": Severity.MODERATE,
-    "ALERT_LVL_4": Severity.EXTREME,
+    "LU-Alert Amber": Severity.MODERATE, # Specific for AMBER alerts
 }
 
 


### PR DESCRIPTION
…icial LU-Alert documentation. The user pointed out that the previous mapping was incorrect and provided a link to the documentation.

The new mapping correctly interprets the `N1`, `N2`, and `N3` levels as `Extreme` (Red), `Severe` (Orange), and `Moderate` (Yellow) respectively.

This change ensures that alert severities are reported accurately. My apologies for the earlier mistake and thanks to the user for their persistence and for providing the crucial information.