### PR TITLE
This commit adds support for newly discovered severity codes (`D`, `L…

### DIFF
--- a/custom_components/lu_alert/coordinator.py
+++ b/custom_components/lu_alert/coordinator.py
@@ -44,12 +44,17 @@ LEVEL_TO_SEVERITY = {
     "N2": Severity.SEVERE,
     "N3": Severity.MODERATE,
 
-    # Fallback for older or different formats observed in data
-    "ALERT_LVL_4": Severity.EXTREME,   # Red
-    "ALERT_LVL_3": Severity.SEVERE,    # Orange
-    "ALERT_LVL_2": Severity.MODERATE,  # Yellow
+    # Codes discovered from website text (D=Danger, L1/L2=Levels)
+    "D": Severity.EXTREME,
+    "L2": Severity.SEVERE,
+    "L1": Severity.MODERATE,
+
+    # Fallback for older or other formats observed in data
+    "ALERT_LVL_4": Severity.EXTREME,
+    "ALERT_LVL_3": Severity.SEVERE,
+    "ALERT_LVL_2": Severity.MODERATE,
     "ALERT_LVL_1": Severity.MINOR,
-    "LU-Alert Amber": Severity.MODERATE, # Specific for AMBER alerts
+    "LU-Alert Amber": Severity.MODERATE,
 }
 
 


### PR DESCRIPTION
…1`, `L2`) that were found in the alert data. The previous version of the code did not recognize these codes, causing alerts with these severities to be incorrectly categorized as "Unknown" and filtered out.

This fix ensures that these alerts are now correctly mapped to their corresponding severity levels (Extreme, Severe, Moderate), allowing them to be displayed correctly based on the user's filter settings.

My sincere thanks to the user for their persistence and for providing the data that made this fix possible.