### PR TITLE
This commit provides a definitive fix for the persistent severity par…

### DIFF
--- a/custom_components/lu_alert/coordinator.py
+++ b/custom_components/lu_alert/coordinator.py
@@ -39,21 +39,24 @@ SEVERITY_ORDER = {
 
 # Mapping from cb-lu-level parameter to Severity enum
 LEVEL_TO_SEVERITY = {
-    # Official mapping from lu-alert.lu (N1=Red, N2=Orange, N3=Yellow)
+    # Extreme (Red alerts)
     "N1": Severity.EXTREME,
-    "N2": Severity.SEVERE,
-    "N3": Severity.MODERATE,
-
-    # Codes discovered from website text (D=Danger, L1/L2=Levels)
     "D": Severity.EXTREME,
-    "L2": Severity.SEVERE,
-    "L1": Severity.MODERATE,
-
-    # Fallback for older or other formats observed in data
     "ALERT_LVL_4": Severity.EXTREME,
+
+    # Severe (Orange alerts)
+    "N2": Severity.SEVERE,
+    "L2": Severity.SEVERE,
     "ALERT_LVL_3": Severity.SEVERE,
-    "ALERT_LVL_2": Severity.MODERATE,
+
+    # Minor (Yellow alerts and Health alerts, per user feedback)
+    "N3": Severity.MINOR,
+    "L1": Severity.MINOR,
+    "L3": Severity.MINOR,
+    "ALERT_LVL_2": Severity.MINOR,
     "ALERT_LVL_1": Severity.MINOR,
+
+    # Moderate (Special case for Amber alerts)
     "LU-Alert Amber": Severity.MODERATE,
 }
 


### PR DESCRIPTION
…sing issues.

Based on extensive user feedback and analysis of various alert data formats, the severity mapping has been completely reworked to be both comprehensive and in line with user expectations.

The key changes are:
- All known codes for "Yellow" weather alerts (N3, L1, ALERT_LVL_2) are now mapped to the `Minor` severity.
- The code for health alerts (L3) is now correctly recognized and also mapped to `Minor`.
- All other known codes (N1, N2, D, L2, etc.) are mapped to their corresponding `Severe` and `Extreme` levels.

This change ensures that when a user selects "Minor" as their minimum severity, they will correctly see all the lowest-level warnings, including yellow weather alerts and health alerts, which resolves the core issue reported by the user.