### PR TITLE
This commit fixes the root cause of the long-standing issue where "Mi…

### DIFF
--- a/custom_components/lu_alert/coordinator.py
+++ b/custom_components/lu_alert/coordinator.py
@@ -108,7 +108,7 @@ class LuAlertDataUpdateCoordinator(DataUpdateCoordinator):
         allowed_categories = {
             Category.GEO, Category.MET, Category.SAFETY, Category.SECURITY,
             Category.RESCUE, Category.FIRE, Category.ENV, Category.TRANSPORT,
-            Category.INFRA
+            Category.INFRA, Category.HEALTH
         }
 
         filtered_alerts = [


### PR DESCRIPTION
…nor" alerts were not being displayed.

The problem was a category filter that was incorrectly excluding all alerts in the "Health" category. These health alerts (food recalls, etc.) correspond to what the user expects to see when they select the "Minor" severity level.

By adding `Category.HEALTH` back into the set of allowed categories, these alerts will no longer be filtered out before the severity check can be performed. This, combined with the comprehensive severity mapping from the previous commit, should finally resolve the issue.

My sincere apologies for the oversight and the prolonged debugging process.