### PR TITLE
Fix: Correct alert severity mapping

### DIFF
--- a/custom_components/lu_alert/coordinator.py
+++ b/custom_components/lu_alert/coordinator.py
@@ -46,14 +46,14 @@ LEVEL_TO_SEVERITY = {
     "L1": Severity.EXTREME,
     "ALERT_LVL_4": Severity.EXTREME,
     "LU-Alert Level 4": Severity.EXTREME,
-    "ALERT_LVL_1": Severity.EXTREME,
-    "LU-Alert Level 1": Severity.EXTREME,
 
     # Severe (Orange alerts, L2/N2)
     "N2": Severity.SEVERE,
     "L2": Severity.SEVERE,
     "ALERT_LVL_2": Severity.SEVERE,
     "LU-Alert Level 2": Severity.SEVERE,
+    "ALERT_LVL_1": Severity.SEVERE,
+    "LU-Alert Level 1": Severity.SEVERE,
 
     # Moderate (Amber alerts, A)
     "A": Severity.MODERATE,
@@ -74,7 +74,7 @@ LEVEL_TO_SEVERITY = {
 }
 
 # Set of alert levels that should be considered as "Test" and filtered out
-TEST_ALERT_LEVELS = {"LU-Alert Test", "LU-Alert Exercise"}
+TEST_ALERT_LEVELS = {"D", "T", "LU-Alert Test", "LU-Alert Exercise"}
 
 
 class LuAlertDataUpdateCoordinator(DataUpdateCoordinator):


### PR DESCRIPTION
- Updated the severity mapping in `coordinator.py` to correctly map alert levels from the lu-alert service to Home Assistant severities, following the user's specifications.
- Added `Information` and `Test` as new severity levels in `enums.py`.
- Corrected the mapping for `L1`, `L2`, `L3`, `I`, and `D` alerts.
- Updated the severity order to include the new levels.
- Remapped `ALERT_LVL_1` and `LU-Alert Level 1` to `Severe` based on user feedback.
- Restored `D` and `T` to the `TEST_ALERT_LEVELS` set to ensure they are filtered correctly.