### PR TITLE
Fix: Correct severity mapping and filtering logic

### DIFF
--- a/custom_components/lu_alert/config_flow.py
+++ b/custom_components/lu_alert/config_flow.py
@@ -52,7 +52,7 @@ class LuAlertConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return LuAlertOptionsFlowHandler(config_entry)
 
 
-class LuAlertOptionsFlowHandler(config_entries.OptionsFlow):
+class LuAlertOptionsFlowHandler(config_entries.OptionsFlowWithReload):
     """Handle an options flow for LU-Alert."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:


### PR DESCRIPTION
This commit addresses multiple issues to improve the accuracy and functionality of the LU-Alert integration.

1.  **Corrected Severity Mapping:** The `LEVEL_TO_SEVERITY` mapping has been updated to be a comprehensive mapping that includes both the official `LU-Alert` levels from the documentation and other observed values from the live data feed. This resolves inconsistencies where some alerts were being assigned incorrect severity levels (e.g., "Information" alerts showing as "Extreme").

2.  **Fixed Severity Filtering:** The logic for reading the minimum severity filter has been corrected. The code now checks both the config entry's `options` and `data` dictionaries to retrieve the user's selected minimum severity.

3.  **Enabled Options Reload:** The options flow handler now inherits from `OptionsFlowWithReload` to ensure that the integration is automatically reloaded when the user changes the configuration. This makes the severity filter changes take effect immediately.