### PR TITLE
Fix sensor naming, card visibility, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,3 @@ card:
     - sensor.lu_alert_2
     - sensor.lu_alert_3
 ```
-
-## Troubleshooting
-
-### Integration Logo / Thumbnail Not Appearing
-
-After installation via HACS, if you do not see the LU-Alert logo on the integrations page or in the HACS dashboard, please try the following:
-1.  Force-reload the page in your browser (e.g., Ctrl+F5 or Cmd+Shift+R).
-2.  Clear your browser's cache.
-3.  Restart Home Assistant.
-This is often due to caching on the browser or Home Assistant frontend.

--- a/custom_components/lu_alert/sensor.py
+++ b/custom_components/lu_alert/sensor.py
@@ -139,8 +139,16 @@ class LuAlertIndexedSensor(LuAlertBaseSensor):
         """Initialize the indexed sensor."""
         super().__init__(coordinator, entry)
         self.index = index
+        # The unique ID needs to be stable and unique
         self._attr_unique_id = f"{self.entry.entry_id}_{index + 1}"
-        self._attr_name = f"{DEFAULT_NAME} {index + 1}"
+        # This will be used to generate the entity_id, e.g., sensor.lu_alert_1
+        self._attr_name = f"{index + 1}"
+
+    @property
+    def name(self) -> str:
+        """Return the friendly name of the sensor."""
+        # This will be the friendly name shown in the UI
+        return f"{DEFAULT_NAME} {self.index + 1}"
 
     @property
     def alert_data(self) -> dict[str, Any] | None:

--- a/custom_components/lu_alert/www/lu-alert-card.js
+++ b/custom_components/lu_alert/www/lu-alert-card.js
@@ -96,3 +96,11 @@ class LuAlertCard extends HTMLElement {
 }
 
 customElements.define('lu-alert-card', LuAlertCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+  type: 'lu-alert-card',
+  name: 'LU-Alert Card',
+  description: 'A card to display LU-Alert (Luxembourg) alerts.',
+  preview: true,
+});


### PR DESCRIPTION
This commit addresses several issues based on user feedback.

1.  **Sensor Naming:** The `LuAlertIndexedSensor` class in `sensor.py` has been updated to correctly generate entity IDs and friendly names. The entity ID is now generated from the index (e.g., `sensor.lu_alert_1`), and the friendly name is set via the `name` property (e.g., "LU-Alert 1").

2.  **Dashboard Card Visibility:** The `lu-alert-card.js` file has been updated to include the necessary code to register the card with the Home Assistant frontend by adding itself to the `window.customCards` array. This makes the card discoverable in the dashboard UI.

3.  **README Update:** The "Troubleshooting" section has been removed from the `README.md` file as requested.