### PR TITLE
Fix incorrect indexed sensor entity IDs

### DIFF
--- a/custom_components/lu_alert/sensor.py
+++ b/custom_components/lu_alert/sensor.py
@@ -145,12 +145,6 @@ class LuAlertIndexedSensor(LuAlertBaseSensor):
         self._attr_name = f"{index + 1}"
 
     @property
-    def name(self) -> str:
-        """Return the friendly name of the sensor."""
-        # This will be the friendly name shown in the UI
-        return f"{DEFAULT_NAME} {self.index + 1}"
-
-    @property
     def alert_data(self) -> dict[str, Any] | None:
         """Return the alert data for this sensor's index."""
         if self.coordinator.data and len(self.coordinator.data.get("alerts", [])) > self.index:


### PR DESCRIPTION
The LuAlertIndexedSensor class incorrectly defined a `name` property, which caused Home Assistant to generate entity IDs with a double prefix (e.g., `sensor.lu_alert_lu_alert_1`).

This was happening because the base class has `_attr_has_entity_name = True`, and the `name` property in the subclass was overriding the intended naming behavior.

By removing the `name` property, the entity ID is now correctly generated from the integration's domain and the sensor's `_attr_name`, resulting in the expected `sensor.lu_alert_1` format. This also fixes the conditional dashboard card example from the README, which relied on the correct entity IDs.