### PR TITLE
Fix friendly name for indexed sensors

### DIFF
--- a/custom_components/lu_alert/sensor.py
+++ b/custom_components/lu_alert/sensor.py
@@ -131,6 +131,7 @@ class LuAlertHighestSeveritySensor(LuAlertBaseSensor):
 class LuAlertIndexedSensor(LuAlertBaseSensor):
     """A sensor for a single alert, identified by its index."""
 
+    _attr_has_entity_name = False  # Override base class
     _attr_icon = "mdi:alert-outline"
 
     def __init__(
@@ -141,8 +142,8 @@ class LuAlertIndexedSensor(LuAlertBaseSensor):
         self.index = index
         # The unique ID needs to be stable and unique
         self._attr_unique_id = f"{self.entry.entry_id}_{index + 1}"
-        # This will be used to generate the entity_id, e.g., sensor.lu_alert_1
-        self._attr_name = f"{index + 1}"
+        # Set the full friendly name. The entity ID will be derived from this.
+        self._attr_name = f"{DEFAULT_NAME} {index + 1}"
 
     @property
     def alert_data(self) -> dict[str, Any] | None:


### PR DESCRIPTION
The indexed sensors (e.g., sensor.lu_alert_1) were displaying their name in the UI as just a number ("1") instead of a descriptive name.

This was caused by the previous fix that set `_attr_name` to just the index.

This commit corrects the behavior by overriding `_attr_has_entity_name` to `False` specifically for the `LuAlertIndexedSensor` class and setting `_attr_name` to the full desired friendly name (e.g., "LU-Alert 1").

This approach ensures the entity ID remains correct (`sensor.lu_alert_1`) while providing a user-friendly name in the UI.