### PR TITLE
Update the manual installation instructions in the README to point to…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If the card is not available automatically, you can register it manually:
 1.  Go to **Settings** > **Dashboards**.
 2.  Click the three dots (⋮) in the top-right corner and select **Resources**.
 3.  Click the **+ ADD RESOURCE** button.
-4.  Set the **URL** to `/hacsfiles/lu_alert/lu-alert-card.js`.
+4.  Set the **URL** to `/hacsfiles/Lux-Alert-HACS-integration/lu-alert-card.js`.
 5.  Set the **Resource Type** to `JavaScript Module`.
 6.  Click **CREATE**.
 


### PR DESCRIPTION
… the correct HACS resource URL for the lu-alert-card.js file.

The previous URL was based on the integration domain (`lu_alert`), but the correct URL should be based on the HACS repository name (`Lux-Alert-HACS-integration`).

This change ensures that users who need to manually add the resource will use the correct path, allowing the custom card to be loaded successfully.