### PR TITLE
Fix duplicate alerts by handling updates and cancellations

### DIFF
--- a/custom_components/lu_alert/manifest.json
+++ b/custom_components/lu_alert/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/koosoli/Lux-Alert-HACS-integration",
   "issue_tracker": "https://github.com/koosoli/Lux-Alert-HACS-integration/issues",
   "codeowners": ["@koosoli"],
-  "version": "1.2.0",
+  "version": "1.2.1",
   "iot_class": "cloud_polling",
   "config_flow": true,
   "dependencies": [],


### PR DESCRIPTION
The lu_alert integration was creating duplicate sensors for alerts because it did not process update and cancellation messages from the data feed. This resulted in multiple sensors showing different stages of the same alert.

This change introduces deduplication logic in the data update coordinator to ensure that only the most recent, active version of each alert is displayed.

The version has been bumped to 1.2.1 to reflect this fix.