### PR TITLE
fix: Correct config flow schema for allergen selector

### DIFF
--- a/custom_components/lu_alert/config_flow.py
+++ b/custom_components/lu_alert/config_flow.py
@@ -88,7 +88,8 @@ class LuAlertConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     SelectSelectorConfig(
                         options=ALLERGEN_LIST,
                         multiple=True,
-                        mode=SelectSelectorMode.DROPDOWN,
+                        mode=SelectSelectorMode.LIST,
+                        custom_value=True,
                     )
                 ),
             }
@@ -170,7 +171,8 @@ class LuAlertOptionsFlowHandler(config_entries.OptionsFlowWithReload):
                     SelectSelectorConfig(
                         options=ALLERGEN_LIST,
                         multiple=True,
-                        mode=SelectSelectorMode.DROPDOWN,
+                        mode=SelectSelectorMode.LIST,
+                        custom_value=True,
                     )
                 ),
             }


### PR DESCRIPTION
This commit fixes a bug that was preventing the integration from being configured. The `SelectSelector` for the new allergen option was using an incorrect mode (`DROPDOWN`) for a multi-select field.

This has been corrected to use `LIST` mode, which is the appropriate choice for multi-select and resolves the "400: Bad Request" error during the config flow initialization.