### PR TITLE
Fix `400: Bad Request` in LU-Alert config flow

### DIFF
--- a/custom_components/lu_alert/config_flow.py
+++ b/custom_components/lu_alert/config_flow.py
@@ -82,9 +82,7 @@ class LuAlertConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(
                     CONF_WATCHLIST_KEYWORDS, default=DEFAULT_WATCHLIST_KEYWORDS
                 ): str,
-                vol.Optional(
-                    CONF_ALLERGENS
-                ): SelectSelector(
+                vol.Optional(CONF_ALLERGENS, default=DEFAULT_ALLERGENS): SelectSelector(
                     SelectSelectorConfig(
                         options=ALLERGEN_LIST,
                         multiple=True,


### PR DESCRIPTION
The config flow was failing with a `400: Bad Request` error when adding the integration. This was caused by the `CONF_ALLERGENS` field in the schema missing a default value.

This change adds `default=DEFAULT_ALLERGENS` to the `vol.Optional` for `CONF_ALLERGENS` in the user config flow. This ensures that the schema has a valid default and prevents the error.